### PR TITLE
Migrate to stable version of Sodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 - rm Cartfile.resolved
 - rm -rf Carthage/
 - brew outdated carthage || brew upgrade carthage
-- carthage bootstrap --platform iOS --cache-builds
+- carthage bootstrap --platform iOS --no-use-binaries
 before_deploy:
 - carthage build --no-skip-current --platform iOS --cache-builds
 - carthage archive $FRAMEWORK_NAME

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "jedisct1/swift-sodium" ~> 8.0
+github "jedisct1/swift-sodium" ~> 0.8.0
 github "attaswift/BigInt" ~> 3.1
 github "krzyzanowskim/CryptoSwift" ~> 0.14.0
 github "keefertaylor/Base58Swift" ~> 1.0.2


### PR DESCRIPTION
Migrate from pulling sodium at head to a stable version.

Checking out sodium causes some odd errors about libsodium not being found. Work around this by forcing carthage to rebuild from source every time.